### PR TITLE
Load things over HTTPS

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
     <link rel="shortcut icon" href="images/favicon.ico" />
 	<link rel="apple-touch-icon" href="images/apple-touch-icon.png"> 
 
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.6.2/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.2/jquery.min.js"></script>
     <script src="js/lastfm.js"></script>
     <script src="js/now-playing.js"></script>
     

--- a/js/lastfm.js
+++ b/js/lastfm.js
@@ -11,7 +11,7 @@ LastfmAPI = function(api_key) {
     this.api_key = api_key;
 };
 LastfmAPI.prototype = {
-    root: 'http://ws.audioscrobbler.com/2.0/',
+    root: 'https://ws.audioscrobbler.com/2.0/',
     
     get: function (method, params, success, error)
     {


### PR DESCRIPTION
GitHub pages is now served over HTTPS, so needs to load dependencies over HTTPS.

Console:

```
Mixed Content: The page at 'https://dsingleton.github.io/now-playing-radiator/#hvk' was loaded over HTTPS, but requested an insecure script 'http://ajax.googleapis.com/ajax/libs/jquery/1.6.2/jquery.min.js'. This request has been blocked; the content must be served over HTTPS.
dsingleton.github.io/:34 Uncaught ReferenceError: $ is not defined
```
